### PR TITLE
Allows cf-ddns.py to open conf file from own directory

### DIFF
--- a/cf-ddns.py
+++ b/cf-ddns.py
@@ -22,9 +22,12 @@ except ImportError:
     from urllib2 import URLError
 
 import json
+import os
 
+__location__ = os.path.realpath(
+    os.path.join(os.getcwd(), os.path.dirname(__file__)))
 
-config_file_name = 'cf-ddns.conf'
+config_file_name = os.path.join(__location__, 'cf-ddns.conf')
 
 with open(config_file_name, 'r') as config_file:
     try:


### PR DESCRIPTION
When running from cron, instead of changing the working directory to the script location, this commit will source the conf file from the script's own directory automatically.

For example, if your crontab entry looks like this:
**/home/user/bin/cf-ddns.py**
you may get a file not found error 
**IOError: [Errno 2] No such file or directory: 'cf-ddns.conf'**

Here we save the script location and then use that to build the patch to the conf file directly.

Hope this helps!